### PR TITLE
添加ros基类

### DIFF
--- a/envs/fixedwing_envs/ardupilot_base_env.py
+++ b/envs/fixedwing_envs/ardupilot_base_env.py
@@ -1,0 +1,509 @@
+"""Base PyFlyt Environment for the Fixedwing model using the Gymnasim API."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Literal
+
+import gymnasium
+import numpy as np
+import pybullet as p
+from gymnasium import spaces
+from PyFlyt.core.utils.compile_helpers import check_numpy
+
+class _AdapterCamera:
+    def __init__(self) -> None:
+        self.view_mat = np.eye(4, dtype=np.float64).reshape(-1).tolist()
+        self.proj_mat = np.eye(4, dtype=np.float64).reshape(-1).tolist()
+        self.is_tracking_camera = False
+
+
+class _AdapterDrone:
+    def __init__(self) -> None:
+        self.camera = _AdapterCamera()
+        self.physics_control_ratio = 8
+        self.physics_camera_ratio = 8
+        self.rgbaImg = None
+        self.depthImg = None
+        self.segImg = None
+
+
+class ArdupilotAdapter:
+    """Minimal Aviary-compatible adapter used during the ROS/ArduPilot migration."""
+
+    GEOM_CYLINDER = 4
+
+    def __init__(
+        self,
+        start_pos: np.ndarray,
+        start_orn: np.ndarray,
+        drone_type: str,
+        render: bool,
+        drone_options: dict[str, Any],
+        np_random: np.random.Generator,
+    ) -> None:
+        self.start_pos = np.asarray(start_pos, dtype=np.float64)
+        self.start_orn = np.asarray(start_orn, dtype=np.float64)
+        self.drone_type = str(drone_type)
+        self.render = bool(render)
+        self.drone_options = dict(drone_options)
+        self.np_random = np_random
+
+        self.drones = [_AdapterDrone()]
+        self.contact_array = np.zeros((1, 1), dtype=bool)
+        self._mode = 0
+        self._wind_field_fn = None
+
+        self._ang_vel = np.zeros((3,), dtype=np.float64)
+        self._ang_pos = self.start_orn[0].copy()
+        self._lin_vel = np.zeros((3,), dtype=np.float64)
+        self._lin_pos = self.start_pos[0].copy()
+        self._aux = np.zeros((6,), dtype=np.float64)
+        self._last_setpoint = np.zeros((4,), dtype=np.float64)
+
+        self._next_uid = 1
+        self._body_ids: list[int] = []
+
+    def disconnect(self) -> None:
+        pass
+
+    def register_wind_field_function(self, fn: Callable[[float, np.ndarray], np.ndarray]) -> None:
+        self._wind_field_fn = fn
+
+    def getDebugVisualizerCamera(self):
+        return ()
+
+    def register_all_new_bodies(self) -> None:
+        pass
+
+    def set_mode(self, mode: int) -> None:
+        self._mode = int(mode)
+
+    def step(self) -> None:
+        pass
+
+    def state(
+        self, idx: int
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        _ = idx
+        return (
+            self._ang_vel.copy(),
+            self._ang_pos.copy(),
+            self._lin_vel.copy(),
+            self._lin_pos.copy(),
+        )
+
+    def aux_state(self, idx: int) -> np.ndarray:
+        _ = idx
+        return self._aux.copy()
+
+    def set_setpoint(self, idx: int, action: np.ndarray) -> None:
+        _ = idx
+        self._last_setpoint = np.asarray(action, dtype=np.float64).copy()
+
+    def getQuaternionFromEuler(self, euler_xyz: list[float]) -> tuple[float, float, float, float]:
+        return p.getQuaternionFromEuler(euler_xyz)
+
+    def getMatrixFromQuaternion(self, quat_xyzw: tuple[float, float, float, float]) -> list[float]:
+        return p.getMatrixFromQuaternion(quat_xyzw)
+
+    def _new_uid(self) -> int:
+        uid = self._next_uid
+        self._next_uid += 1
+        return uid
+
+    def loadURDF(self, *args: Any, **kwargs: Any) -> int:
+        _ = args, kwargs
+        uid = self._new_uid()
+        self._body_ids.append(uid)
+        return uid
+
+    def getNumBodies(self) -> int:
+        return len(self._body_ids)
+
+    def getBodyUniqueId(self, index: int) -> int:
+        i = int(index)
+        if i < 0 or i >= len(self._body_ids):
+            return -1
+        return int(self._body_ids[i])
+
+    def removeBody(self, body_id: int) -> None:
+        try:
+            self._body_ids.remove(int(body_id))
+        except ValueError:
+            pass
+
+    def createCollisionShape(self, *args: Any, **kwargs: Any) -> int:
+        _ = args, kwargs
+        return self._new_uid()
+
+    def createVisualShape(self, *args: Any, **kwargs: Any) -> int:
+        _ = args, kwargs
+        return self._new_uid()
+
+    def createMultiBody(self, *args: Any, **kwargs: Any) -> int:
+        _ = args, kwargs
+        uid = self._new_uid()
+        self._body_ids.append(uid)
+        return uid
+
+    def loadPlugin(self, *args: Any, **kwargs: Any) -> int:
+        _ = args, kwargs
+        return 0
+
+    def changeVisualShape(self, *args: Any, **kwargs: Any) -> None:
+        _ = args, kwargs
+
+
+class FixedwingBaseEnv(gymnasium.Env):
+    """Base PyFlyt Environment for the Fixedwing model using the Gymnasim API."""
+
+    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 30}
+
+    def __init__(
+        self,
+        start_pos: np.ndarray = np.array([[0.0, 0.0, 1.0]]),
+        start_orn: np.ndarray = np.array([[0.0, 0.0, 0.0]]),
+        flight_mode: int = 0,
+        flight_dome_size: float = np.inf,
+        max_duration_seconds: float = 10.0,
+        angle_representation: Literal["euler", "quaternion"] = "quaternion",
+        agent_hz: int = 30,
+        render_mode: None | Literal["human", "rgb_array"] = None,
+        render_resolution: tuple[int, int] = (480, 480),
+        wind_config: None | dict[str, Any] = None,
+    ):
+        """__init__.
+
+        Args:
+            start_pos (np.ndarray): start_pos
+            start_orn (np.ndarray): start_orn
+            flight_mode (int): flight_mode
+            flight_dome_size (float): flight_dome_size
+            max_duration_seconds (float): max_duration_seconds
+            angle_representation (Literal["euler", "quaternion"]): angle_representation
+            agent_hz (int): agent_hz
+            render_mode (None | Literal["human", "rgb_array"]): render_mode
+            render_resolution (tuple[int, int]): render_resolution
+
+        """
+        if 120 % agent_hz != 0:
+            lowest = int(120 / (int(120 / agent_hz) + 1))
+            highest = int(120 / int(120 / agent_hz))
+            raise ValueError(
+                f"`agent_hz` must be round denominator of 120, try {lowest} or {highest}."
+            )
+
+        if render_mode and render_mode not in self.metadata["render_modes"]:
+            raise ValueError(
+                f"Invalid render mode {render_mode}, only {self.metadata['render_modes']} allowed."
+            )
+        self.render_mode = render_mode
+        self.render_resolution = render_resolution
+        self.wind_config = wind_config
+
+        """GYMNASIUM STUFF"""
+        # attitude size increases by 1 for quaternion
+        if angle_representation == "euler":
+            attitude_shape = 12
+        elif angle_representation == "quaternion":
+            attitude_shape = 13
+        else:
+            raise ValueError(
+                f"angle_representation must be either `euler` or `quaternion`, not {angle_representation}"
+            )
+
+        self.attitude_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=(attitude_shape,), dtype=np.float64
+        )
+        self.auxiliary_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=(6,), dtype=np.float64
+        )
+        high = np.ones((4,), dtype=np.float64)
+        low = -high
+        self.action_space = spaces.Box(low=low, high=high, dtype=np.float64)
+
+        # the whole implicit state space = attitude + previous action + auxiliary information
+        self.combined_space = spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(
+                attitude_shape
+                + self.action_space.shape[0]
+                + self.auxiliary_space.shape[0],
+            ),
+            dtype=np.float64,
+        )
+
+        """ ENVIRONMENT CONSTANTS """
+        self.start_pos = start_pos
+        self.start_orn = start_orn
+        self.flight_mode = flight_mode
+        self.flight_dome_size = flight_dome_size
+        self.max_steps = int(agent_hz * max_duration_seconds)
+        self.env_step_ratio = int(120 / agent_hz)
+        if angle_representation == "euler":
+            self.angle_representation = 0
+        elif angle_representation == "quaternion":
+            self.angle_representation = 1
+
+    def _maybe_apply_wind_field(self) -> None:
+        cfg = self.wind_config or {}
+        if not bool(cfg.get("enabled", False)):
+            return
+
+        mode = str(cfg.get("mode", "constant")).lower()
+        if mode not in ("constant", "gust_sine"):
+            raise ValueError(f"Unsupported wind mode: {mode}")
+
+        def _sample_vec3(
+            base_key: str, range_key: str, default: tuple[float, float, float]
+        ) -> np.ndarray:
+            base = np.asarray(cfg.get(base_key, default), dtype=np.float64).reshape(3)
+            if not bool(cfg.get("randomize_on_reset", False)):
+                return base
+
+            ranges = cfg.get(range_key, None)
+            if ranges is None:
+                return base
+
+            if (
+                not isinstance(ranges, (list, tuple))
+                or len(ranges) != 3
+                or not all(isinstance(r, (list, tuple)) and len(r) == 2 for r in ranges)
+            ):
+                raise ValueError(f"Invalid {range_key}: {ranges}")
+
+            lows = np.asarray([r[0] for r in ranges], dtype=np.float64)
+            highs = np.asarray([r[1] for r in ranges], dtype=np.float64)
+            return self.np_random.uniform(lows, highs).astype(np.float64)
+
+        base_wind = _sample_vec3(
+            base_key="wind_enu_mps",
+            range_key="wind_enu_mps_range",
+            default=(0.0, 0.0, 0.0),
+        )
+
+        if mode == "constant":
+            wind_enu = base_wind
+
+            def wind_field(time_s: float, positions_m: np.ndarray) -> np.ndarray:
+                n = int(positions_m.shape[0])
+                return np.repeat(wind_enu.reshape(1, 3), repeats=n, axis=0)
+
+            self.env.register_wind_field_function(wind_field)
+            return
+
+        gust_amp = _sample_vec3(
+            base_key="gust_amp_enu_mps",
+            range_key="gust_amp_enu_mps_range",
+            default=(0.0, 0.0, 0.0),
+        )
+        gust_freq_hz = float(cfg.get("gust_freq_hz", 0.0))
+        gust_phase = float(cfg.get("gust_phase_rad", 0.0))
+        if bool(cfg.get("randomize_on_reset", False)) and bool(
+            cfg.get("randomize_gust_phase", True)
+        ):
+            gust_phase = float(self.np_random.uniform(0.0, 2.0 * np.pi))
+
+        def wind_field(time_s: float, positions_m: np.ndarray) -> np.ndarray:
+            n = int(positions_m.shape[0])
+            gust = gust_amp * np.sin(2.0 * np.pi * gust_freq_hz * time_s + gust_phase)
+            wind_enu = base_wind + gust
+            return np.repeat(wind_enu.reshape(1, 3), repeats=n, axis=0)
+
+        self.env.register_wind_field_function(wind_field)
+
+    def reset(
+        self, *, seed: None | int = None, options: None | dict[str, Any] = dict()
+    ) -> tuple[Any, dict]:
+        """reset.
+
+        Args:
+            seed: seed to pass to the base environment.
+            options: None
+
+        """
+        raise NotImplementedError
+
+    def close(self) -> None:
+        """Disconnects the internal Aviary."""
+        # if we already have an env, disconnect from it
+        if hasattr(self, "env"):
+            self.env.disconnect()
+
+    def begin_reset(
+        self,
+        seed: None | int = None,
+        options: None | dict[str, Any] = dict(),
+        drone_options: None | dict[str, Any] = dict(),
+    ) -> None:
+        """The first half of the reset function."""
+        super().reset(seed=seed)
+
+        # if we already have an env, disconnect from it
+        if hasattr(self, "env"):
+            self.env.disconnect()
+
+        self.step_count = 0
+        self.termination = False
+        self.truncation = False
+        self.state = None
+        self.action = np.zeros((4,))
+        self.reward = 0.0
+        self.info = {}
+        self.info["out_of_bounds"] = False
+        self.info["collision"] = False
+        self.info["env_complete"] = False
+
+        # need to handle Nones
+        if options is None:
+            options = dict()
+        if drone_options is None:
+            drone_options = dict()
+
+        # camera handling
+        drone_options["use_camera"] = drone_options.get("use_camera", False) or bool(
+            self.render_mode
+        )
+        drone_options["camera_fps"] = int(120 / self.env_step_ratio)
+
+        # init env
+        self.env = ArdupilotAdapter(
+            start_pos=self.start_pos,
+            start_orn=self.start_orn,
+            drone_type="fixedwing",
+            render=self.render_mode == "human",
+            drone_options=drone_options,
+            np_random=self.np_random,
+        )
+        self._maybe_apply_wind_field()
+
+        if self.render_mode == "human":
+            self.camera_parameters = self.env.getDebugVisualizerCamera()
+
+    def end_reset(
+        self, seed: None | int = None, options: None | dict[str, Any] = dict()
+    ) -> None:
+        """The tailing half of the reset function."""
+        # register all new collision bodies
+        self.env.register_all_new_bodies()
+
+        # set flight mode
+        self.env.set_mode(self.flight_mode)
+
+        # wait for env to stabilize
+        for _ in range(10):
+            self.env.step()
+
+        self.compute_state()
+
+    def compute_state(self) -> None:
+        """Computes the state of the Rocket."""
+        raise NotImplementedError
+
+    def compute_auxiliary(self) -> np.ndarray:
+        """This returns the auxiliary state form the drone."""
+        return self.env.aux_state(0)
+
+    def compute_attitude(
+        self,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """state.
+
+        This returns the base attitude for the drone.
+        - ang_vel (vector of 3 values)
+        - ang_pos (vector of 3/4 values)
+        - lin_vel (vector of 3 values)
+        - lin_pos (vector of 3 values)
+        - quaternion (vector of 4 values)
+        """
+        raw_state = self.env.state(0)
+
+        # state breakdown
+        ang_vel = raw_state[0]
+        ang_pos = raw_state[1]
+        lin_vel = raw_state[2]
+        lin_pos = raw_state[3]
+
+        # quaternion angles
+        quaternion = p.getQuaternionFromEuler(ang_pos)
+
+        return ang_vel, ang_pos, lin_vel, lin_pos, quaternion
+
+    def compute_term_trunc_reward(self) -> None:
+        """compute_term_trunc_reward."""
+        raise NotImplementedError
+
+    def compute_base_term_trunc_reward(self) -> None:
+        """compute_base_term_trunc_reward."""
+        # exceed step count
+        if self.step_count > self.max_steps:
+            self.truncation |= True
+
+        # collision
+        if np.any(self.env.contact_array):
+            self.reward = -100.0
+            self.info["collision"] = True
+            self.termination |= True
+
+        # exceed flight dome
+        if np.linalg.norm(self.env.state(0)[-1]) > self.flight_dome_size:
+            self.reward = -100.0
+            self.info["out_of_bounds"] = True
+            self.termination |= True
+
+    def step(self, action: np.ndarray) -> tuple[Any, float, bool, bool, dict]:
+        """Steps the environment.
+
+        Args:
+            action (np.ndarray): action
+
+        Returns:
+            state, reward, termination, truncation, info
+
+        """
+        # reset the reward
+        self.reward = -0.1
+
+        # pass the action, but clip the throttle
+        self.action = action.copy()
+        aviary_action = action.copy()
+        aviary_action[..., -1] = (aviary_action[..., -1] / 2.0) + 0.5
+        self.env.set_setpoint(0, aviary_action)
+
+        # step through env, the internal env updates a few steps before the outer env
+        for _ in range(self.env_step_ratio):
+            # if we've already ended, don't continue
+            if self.termination or self.truncation:
+                break
+
+            self.env.step()
+
+            # compute state and done
+            self.compute_state()
+            self.compute_term_trunc_reward()
+
+        # increment step count
+        self.step_count += 1
+
+        return self.state, self.reward, self.termination, self.truncation, self.info
+    def render(self) -> np.ndarray:
+        """Render."""
+        check_numpy()
+        if self.render_mode is None:
+            raise ValueError(
+                "Please set `render_mode='human'` or `render_mode='rgb_array'` in init to use this function."
+            )
+
+        _, _, rgbaImg, _, _ = self.env.getCameraImage(
+            width=self.render_resolution[1],
+            height=self.render_resolution[0],
+            viewMatrix=self.env.drones[0].camera.view_mat,
+            projectionMatrix=self.env.drones[0].camera.proj_mat,
+        )
+
+        rgbaImg = np.asarray(rgbaImg, dtype=np.uint8).reshape(
+            self.render_resolution[0], self.render_resolution[1], -1
+        )
+
+        return rgbaImg

--- a/envs/fixedwing_envs/ardupilot_base_env.py
+++ b/envs/fixedwing_envs/ardupilot_base_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any, Callable, Literal
 
 import gymnasium
@@ -31,6 +32,23 @@ class ArdupilotAdapter:
     """Minimal Aviary-compatible adapter used during the ROS/ArduPilot migration."""
 
     GEOM_CYLINDER = 4
+
+    @staticmethod
+    def _quat_to_euler_xyz(qx: float, qy: float, qz: float, qw: float) -> tuple[float, float, float]:
+        sinr_cosp = 2.0 * (qw * qx + qy * qz)
+        cosr_cosp = 1.0 - 2.0 * (qx * qx + qy * qy)
+        roll = float(np.arctan2(sinr_cosp, cosr_cosp))
+
+        sinp = 2.0 * (qw * qy - qz * qx)
+        if abs(sinp) >= 1.0:
+            pitch = float(np.sign(sinp) * (np.pi / 2.0))
+        else:
+            pitch = float(np.arcsin(sinp))
+
+        siny_cosp = 2.0 * (qw * qz + qx * qy)
+        cosy_cosp = 1.0 - 2.0 * (qy * qy + qz * qz)
+        yaw = float(np.arctan2(siny_cosp, cosy_cosp))
+        return roll, pitch, yaw
 
     def __init__(
         self,
@@ -63,8 +81,143 @@ class ArdupilotAdapter:
         self._next_uid = 1
         self._body_ids: list[int] = []
 
+        self._rclpy = None
+        self._node = None
+        self._executor = None
+        self._owns_rclpy_init = False
+        self._ros_state_ready = False
+        self._state_update_seq = 0
+        self._init_mavros_state_subscribers()
+
     def disconnect(self) -> None:
-        pass
+        try:
+            if self._executor is not None and self._node is not None:
+                self._executor.remove_node(self._node)
+        except Exception:
+            pass
+
+        try:
+            if self._node is not None:
+                self._node.destroy_node()
+        except Exception:
+            pass
+
+        if self._rclpy is not None and self._owns_rclpy_init:
+            try:
+                if self._rclpy.ok():
+                    self._rclpy.shutdown()
+            except Exception:
+                pass
+
+        self._executor = None
+        self._node = None
+        self._rclpy = None
+        self._owns_rclpy_init = False
+        self._ros_state_ready = False
+
+    def _init_mavros_state_subscribers(self) -> None:
+        try:
+            from copy import deepcopy
+            import rclpy
+            from geometry_msgs.msg import TwistStamped
+            from nav_msgs.msg import Odometry
+            from rclpy.executors import SingleThreadedExecutor
+            from rclpy.node import Node
+            from rclpy.qos import qos_profile_sensor_data
+            from sensor_msgs.msg import Imu
+        except Exception:
+            return
+
+        try:
+            if not rclpy.ok():
+                rclpy.init(args=None)
+                self._owns_rclpy_init = True
+
+            self._rclpy = rclpy
+            self._node = Node(f"ardupilot_adapter_{int(time.time() * 1000) % 1000000}")
+            self._executor = SingleThreadedExecutor()
+            self._executor.add_node(self._node)
+
+            _mavros_imu_topic = str(
+                self.drone_options.get("mavros_imu_topic", "/mavros/imu/data")
+            )
+            _mavros_odom_topic = str(
+                self.drone_options.get("mavros_odom_topic", "/mavros/local_position/odom")
+            )
+            _mavros_vel_topic = str(
+                self.drone_options.get("mavros_vel_topic", "/mavros/local_position/velocity_local")
+            )
+            qos_latest = deepcopy(qos_profile_sensor_data)
+            qos_latest.depth = 1
+            self._node.create_subscription(
+                Imu,
+                _mavros_imu_topic,
+                self._on_imu,
+                qos_latest,
+            )
+            self._node.create_subscription(
+                Odometry,
+                _mavros_odom_topic,
+                self._on_odom,
+                qos_latest,
+            )
+            self._node.create_subscription(
+                TwistStamped,
+                _mavros_vel_topic,
+                self._on_vel,
+                qos_latest,
+            )
+            self._ros_state_ready = True
+        except Exception:
+            self._ros_state_ready = False
+
+    def _spin_ros_once(self, timeout_sec: float = 0.0) -> None:
+        if self._executor is None:
+            return
+        try:
+            self._executor.spin_once(timeout_sec=timeout_sec)
+        except TypeError:
+            self._executor.spin_once(timeout_sec)
+        except Exception:
+            pass
+
+    def _on_imu(self, msg: Any) -> None:
+        try:
+            av = msg.angular_velocity
+            q = msg.orientation
+            self._ang_vel = np.array([av.x, av.y, av.z], dtype=np.float64)
+            roll, pitch, yaw = self._quat_to_euler_xyz(
+                float(q.x), float(q.y), float(q.z), float(q.w)
+            )
+            self._ang_pos = np.array([roll, pitch, yaw], dtype=np.float64)
+            self._state_update_seq += 1
+        except Exception:
+            return
+
+    def _on_odom(self, msg: Any) -> None:
+        try:
+            pmsg = msg.pose.pose.position
+            qmsg = msg.pose.pose.orientation
+            vmsg = msg.twist.twist.linear
+
+            self._lin_pos = np.array([pmsg.x, pmsg.y, pmsg.z], dtype=np.float64)
+            self._lin_vel = np.array([vmsg.x, vmsg.y, vmsg.z], dtype=np.float64)
+
+            roll, pitch, yaw = self._quat_to_euler_xyz(
+                float(qmsg.x), float(qmsg.y), float(qmsg.z), float(qmsg.w)
+            )
+            self._ang_pos = np.array([roll, pitch, yaw], dtype=np.float64)
+            self._state_update_seq += 1
+        except Exception:
+            return
+
+    def _on_vel(self, msg: Any) -> None:
+        try:
+            vmsg = msg.twist.linear
+            self._lin_vel = np.array([vmsg.x, vmsg.y, vmsg.z], dtype=np.float64)
+            self._state_update_seq += 1
+        except Exception:
+            return
 
     def register_wind_field_function(self, fn: Callable[[float, np.ndarray], np.ndarray]) -> None:
         self._wind_field_fn = fn
@@ -79,12 +232,19 @@ class ArdupilotAdapter:
         self._mode = int(mode)
 
     def step(self) -> None:
-        pass
+        self._spin_ros_once(timeout_sec=0.0)
 
     def state(
         self, idx: int
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         _ = idx
+        # Drain currently queued state callbacks before returning.
+        # With depth=1 per topic, this effectively syncs to latest queued samples.
+        for _ in range(16):
+            prev_seq = self._state_update_seq
+            self._spin_ros_once(timeout_sec=0.0)
+            if self._state_update_seq == prev_seq:
+                break
         return (
             self._ang_vel.copy(),
             self._ang_pos.copy(),

--- a/envs/fixedwing_envs/ardupilot_base_env.py
+++ b/envs/fixedwing_envs/ardupilot_base_env.py
@@ -88,6 +88,25 @@ class ArdupilotAdapter:
         self._rc_pwm_min = float(self.drone_options.get("mavros_rc_pwm_min", 1000.0))
         self._rc_pwm_max = float(self.drone_options.get("mavros_rc_pwm_max", 2000.0))
         self._rc_pwm_trim = float(self.drone_options.get("mavros_rc_pwm_trim", 1500.0))
+        self._control_mode = str(
+            self.drone_options.get("control_mode", "rc_override")
+        ).strip().lower()
+        self._mavros_rc_override_topic = str(
+            self.drone_options.get("mavros_rc_override_topic", "/mavros/rc/override")
+        )
+        self._rc_override_roll_channel = int(
+            self.drone_options.get("mavros_rc_roll_channel", 0)
+        )  # RC1
+        self._rc_override_pitch_channel = int(
+            self.drone_options.get("mavros_rc_pitch_channel", 1)
+        )  # RC2
+        self._rc_override_yaw_channel = int(
+            self.drone_options.get("mavros_rc_yaw_channel", 3)
+        )  # RC4
+        self._rc_override_throttle_channel = int(
+            self.drone_options.get("mavros_rc_throttle_channel", 2)
+        )  # RC3
+
         self._vision_rgb_topic = str(
             self.drone_options.get("vision_rgb_topic", "/camera/image_raw")
         )
@@ -105,6 +124,10 @@ class ArdupilotAdapter:
         self._rclpy = None
         self._node = None
         self._executor = None
+        self._rc_override_pub = None
+        self._OverrideRCIn = None
+        self._rc_chan_nochange = 65535
+        self._rc_channel_count = 18
         self._owns_rclpy_init = False
         self._ros_state_ready = False
         self._state_update_seq = 0
@@ -146,7 +169,7 @@ class ArdupilotAdapter:
             from rclpy.node import Node
             from rclpy.qos import qos_profile_sensor_data
             from sensor_msgs.msg import Image, Imu
-            from mavros_msgs.msg import RCOut
+            from mavros_msgs.msg import RCOut, OverrideRCIn
         except Exception:
             return
 
@@ -197,6 +220,19 @@ class ArdupilotAdapter:
                     _mavros_rc_out_topic,
                     self._on_rc_out,
                     qos_latest,
+                )
+            if self._control_mode == "rc_override":
+                self._rc_override_pub = self._node.create_publisher(
+                    OverrideRCIn,
+                    self._mavros_rc_override_topic,
+                    qos_latest,
+                )
+                self._OverrideRCIn = OverrideRCIn
+                self._rc_chan_nochange = int(
+                    getattr(OverrideRCIn, "CHAN_NOCHANGE", 65535)
+                )
+                self._rc_channel_count = int(
+                    len(getattr(OverrideRCIn(), "channels", [0] * 18))
                 )
             self._node.create_subscription(
                 Image,
@@ -269,6 +305,21 @@ class ArdupilotAdapter:
     def _norm_throttle_pwm(self, pwm_value: float) -> float:
         span = max(1.0, self._rc_pwm_max - self._rc_pwm_min)
         return float(np.clip((pwm_value - self._rc_pwm_min) / span, 0.0, 1.0))
+
+    def _surface_norm_to_pwm(self, value: float) -> int:
+        v = float(np.clip(value, -1.0, 1.0))
+        span = max(1.0, 0.5 * (self._rc_pwm_max - self._rc_pwm_min))
+        pwm = self._rc_pwm_trim + (v * span)
+        return int(np.clip(np.round(pwm), self._rc_pwm_min, self._rc_pwm_max))
+
+    def _throttle_norm_to_pwm(self, value: float) -> int:
+        v = float(value)
+        # Support both [-1, 1] and [0, 1] throttle conventions.
+        if v < 0.0:
+            v = (v + 1.0) * 0.5
+        v = float(np.clip(v, 0.0, 1.0))
+        pwm = self._rc_pwm_min + v * (self._rc_pwm_max - self._rc_pwm_min)
+        return int(np.clip(np.round(pwm), self._rc_pwm_min, self._rc_pwm_max))
     def _on_rc_out(self, msg: Any) -> None:
         try:
             channels = np.asarray(msg.channels, dtype=np.float64).reshape(-1)
@@ -406,6 +457,81 @@ class ArdupilotAdapter:
     def getDebugVisualizerCamera(self):
         return ()
 
+    @staticmethod
+    def _resize_image_nearest(img: np.ndarray, out_h: int, out_w: int) -> np.ndarray:
+        arr = np.asarray(img)
+        if arr.ndim < 2:
+            return arr
+        in_h, in_w = int(arr.shape[0]), int(arr.shape[1])
+        if in_h == out_h and in_w == out_w:
+            return arr
+        if in_h <= 0 or in_w <= 0 or out_h <= 0 or out_w <= 0:
+            return arr
+        y_idx = np.clip(
+            np.round(np.linspace(0, in_h - 1, out_h)).astype(np.int64), 0, in_h - 1
+        )
+        x_idx = np.clip(
+            np.round(np.linspace(0, in_w - 1, out_w)).astype(np.int64), 0, in_w - 1
+        )
+        if arr.ndim == 2:
+            return arr[y_idx][:, x_idx]
+        return arr[y_idx][:, x_idx, ...]
+
+    def getCameraImage(self, *args: Any, **kwargs: Any):
+        width = int(kwargs.get("width", 0) or 0)
+        height = int(kwargs.get("height", 0) or 0)
+        if width <= 0 and len(args) >= 1:
+            width = int(args[0])
+        if height <= 0 and len(args) >= 2:
+            height = int(args[1])
+        if width <= 0:
+            width = 640
+        if height <= 0:
+            height = 480
+
+        drone = self.drones[0]
+
+        rgba = getattr(drone, "rgbaImg", None)
+        if rgba is None:
+            rgba_arr = np.zeros((height, width, 4), dtype=np.uint8)
+        else:
+            rgba_arr = np.asarray(rgba)
+            if rgba_arr.ndim == 2:
+                rgba_arr = np.repeat(rgba_arr[..., None], 4, axis=-1)
+            elif rgba_arr.ndim == 3 and rgba_arr.shape[-1] == 3:
+                alpha = np.full((rgba_arr.shape[0], rgba_arr.shape[1], 1), 255, dtype=np.uint8)
+                rgba_arr = np.concatenate([rgba_arr, alpha], axis=-1)
+            elif rgba_arr.ndim == 3 and rgba_arr.shape[-1] == 1:
+                rgba_arr = np.repeat(rgba_arr, 4, axis=-1)
+                rgba_arr[..., 3] = 255
+            elif rgba_arr.ndim != 3 or rgba_arr.shape[-1] < 4:
+                rgba_arr = np.zeros((height, width, 4), dtype=np.uint8)
+            rgba_arr = self._resize_image_nearest(rgba_arr, height, width).astype(np.uint8, copy=False)
+
+        depth = getattr(drone, "depthImg", None)
+        if depth is None:
+            depth_arr = np.zeros((height, width, 1), dtype=np.float32)
+        else:
+            depth_arr = np.asarray(depth)
+            if depth_arr.ndim == 2:
+                depth_arr = depth_arr[..., None]
+            elif depth_arr.ndim == 3 and depth_arr.shape[-1] > 1:
+                depth_arr = depth_arr[..., :1]
+            depth_arr = self._resize_image_nearest(depth_arr, height, width).astype(np.float32, copy=False)
+
+        seg = getattr(drone, "segImg", None)
+        if seg is None:
+            seg_arr = np.full((height, width, 1), -1, dtype=np.int32)
+        else:
+            seg_arr = np.asarray(seg)
+            if seg_arr.ndim == 2:
+                seg_arr = seg_arr[..., None]
+            elif seg_arr.ndim == 3 and seg_arr.shape[-1] > 1:
+                seg_arr = seg_arr[..., :1]
+            seg_arr = self._resize_image_nearest(seg_arr, height, width).astype(np.int32, copy=False)
+
+        return width, height, rgba_arr, depth_arr, seg_arr
+
     def register_all_new_bodies(self) -> None:
         pass
 
@@ -439,7 +565,39 @@ class ArdupilotAdapter:
 
     def set_setpoint(self, idx: int, action: np.ndarray) -> None:
         _ = idx
-        self._last_setpoint = np.asarray(action, dtype=np.float64).copy()
+        act = np.asarray(action, dtype=np.float64).reshape(-1)
+        self._last_setpoint = act.copy()
+
+        if (
+            self._control_mode != "rc_override"
+            or self._rc_override_pub is None
+            or self._OverrideRCIn is None
+            or act.size < 4
+        ):
+            return
+
+        try:
+            msg = self._OverrideRCIn()
+            channels = [int(self._rc_chan_nochange)] * int(self._rc_channel_count)
+
+            roll_pwm = self._surface_norm_to_pwm(act[0])
+            pitch_pwm = self._surface_norm_to_pwm(act[1])
+            yaw_pwm = self._surface_norm_to_pwm(act[2])
+            throttle_pwm = self._throttle_norm_to_pwm(act[3])
+
+            if 0 <= self._rc_override_roll_channel < len(channels):
+                channels[self._rc_override_roll_channel] = roll_pwm
+            if 0 <= self._rc_override_pitch_channel < len(channels):
+                channels[self._rc_override_pitch_channel] = pitch_pwm
+            if 0 <= self._rc_override_yaw_channel < len(channels):
+                channels[self._rc_override_yaw_channel] = yaw_pwm
+            if 0 <= self._rc_override_throttle_channel < len(channels):
+                channels[self._rc_override_throttle_channel] = throttle_pwm
+
+            msg.channels = channels
+            self._rc_override_pub.publish(msg)
+        except Exception:
+            return
 
     def getQuaternionFromEuler(self, euler_xyz: list[float]) -> tuple[float, float, float, float]:
         return p.getQuaternionFromEuler(euler_xyz)

--- a/envs/fixedwing_envs/ardupilot_base_env.py
+++ b/envs/fixedwing_envs/ardupilot_base_env.py
@@ -94,13 +94,9 @@ class ArdupilotAdapter:
         self._vision_depth_topic = str(
             self.drone_options.get("vision_depth_topic", "/camera/depth/image_raw")
         )
-        self._vision_seg_topic = str(
-            self.drone_options.get("vision_seg_topic", "")
-        ).strip()
         self._vision_depth_is_meters = bool(
             self.drone_options.get("vision_depth_is_meters", True)
         )
-        self._has_seg_subscription = False
 
 
         self._next_uid = 1
@@ -214,14 +210,6 @@ class ArdupilotAdapter:
                 self._on_depth_image,
                 qos_latest,
             )
-            if self._vision_seg_topic:
-                self._node.create_subscription(
-                    Image,
-                    self._vision_seg_topic,
-                    self._on_seg_image,
-                    qos_latest,
-                )
-                self._has_seg_subscription = True
             self._ros_state_ready = True
         except Exception:
             self._ros_state_ready = False
@@ -384,8 +372,7 @@ class ArdupilotAdapter:
 
             drone = self.drones[0]
             drone.rgbaImg = np.ascontiguousarray(rgba)
-            if not self._has_seg_subscription:
-                drone.segImg = np.ascontiguousarray(rgba[..., :1])
+
             self._state_update_seq += 1
         except Exception:
             return
@@ -409,16 +396,6 @@ class ArdupilotAdapter:
                 depth_img = np.clip(depth_m, 0.0, 1.0)
 
             self.drones[0].depthImg = np.ascontiguousarray(depth_img[..., None])
-            self._state_update_seq += 1
-        except Exception:
-            return
-
-    def _on_seg_image(self, msg: Any) -> None:
-        try:
-            arr = self._ros_image_to_array(msg)
-            if arr is None:
-                return
-            self.drones[0].segImg = np.ascontiguousarray(arr[..., :1])
             self._state_update_seq += 1
         except Exception:
             return

--- a/envs/fixedwing_envs/ardupilot_base_env.py
+++ b/envs/fixedwing_envs/ardupilot_base_env.py
@@ -77,6 +77,31 @@ class ArdupilotAdapter:
         self._lin_pos = self.start_pos[0].copy()
         self._aux = np.zeros((6,), dtype=np.float64)
         self._last_setpoint = np.zeros((4,), dtype=np.float64)
+        #rc_surface的接收变量名称或许可以简化
+        self._rc_surface_channel_indices = np.asarray(
+            self.drone_options.get("mavros_surface_channel_indices", [0, 1, 2, 3, 4]),
+            dtype=np.int64,
+        ).reshape(-1)
+        self._rc_throttle_channel_index = int(
+            self.drone_options.get("mavros_throttle_channel_index", 5)
+        )
+        self._rc_pwm_min = float(self.drone_options.get("mavros_rc_pwm_min", 1000.0))
+        self._rc_pwm_max = float(self.drone_options.get("mavros_rc_pwm_max", 2000.0))
+        self._rc_pwm_trim = float(self.drone_options.get("mavros_rc_pwm_trim", 1500.0))
+        self._vision_rgb_topic = str(
+            self.drone_options.get("vision_rgb_topic", "/camera/image_raw")
+        )
+        self._vision_depth_topic = str(
+            self.drone_options.get("vision_depth_topic", "/camera/depth/image_raw")
+        )
+        self._vision_seg_topic = str(
+            self.drone_options.get("vision_seg_topic", "")
+        ).strip()
+        self._vision_depth_is_meters = bool(
+            self.drone_options.get("vision_depth_is_meters", True)
+        )
+        self._has_seg_subscription = False
+
 
         self._next_uid = 1
         self._body_ids: list[int] = []
@@ -124,7 +149,8 @@ class ArdupilotAdapter:
             from rclpy.executors import SingleThreadedExecutor
             from rclpy.node import Node
             from rclpy.qos import qos_profile_sensor_data
-            from sensor_msgs.msg import Imu
+            from sensor_msgs.msg import Image, Imu
+            from mavros_msgs.msg import RCOut
         except Exception:
             return
 
@@ -147,6 +173,9 @@ class ArdupilotAdapter:
             _mavros_vel_topic = str(
                 self.drone_options.get("mavros_vel_topic", "/mavros/local_position/velocity_local")
             )
+            _mavros_rc_out_topic = str(
+                    self.drone_options.get("mavros_rc_out_topic", "/mavros/rc/out")
+                )
             qos_latest = deepcopy(qos_profile_sensor_data)
             qos_latest.depth = 1
             self._node.create_subscription(
@@ -167,6 +196,32 @@ class ArdupilotAdapter:
                 self._on_vel,
                 qos_latest,
             )
+            self._node.create_subscription(
+                    RCOut,
+                    _mavros_rc_out_topic,
+                    self._on_rc_out,
+                    qos_latest,
+                )
+            self._node.create_subscription(
+                Image,
+                self._vision_rgb_topic,
+                self._on_rgb_image,
+                qos_latest,
+            )
+            self._node.create_subscription(
+                Image,
+                self._vision_depth_topic,
+                self._on_depth_image,
+                qos_latest,
+            )
+            if self._vision_seg_topic:
+                self._node.create_subscription(
+                    Image,
+                    self._vision_seg_topic,
+                    self._on_seg_image,
+                    qos_latest,
+                )
+                self._has_seg_subscription = True
             self._ros_state_ready = True
         except Exception:
             self._ros_state_ready = False
@@ -215,6 +270,155 @@ class ArdupilotAdapter:
         try:
             vmsg = msg.twist.linear
             self._lin_vel = np.array([vmsg.x, vmsg.y, vmsg.z], dtype=np.float64)
+            self._state_update_seq += 1
+        except Exception:
+            return
+
+    def _norm_surface_pwm(self, pwm_value: float) -> float:
+        span = max(1.0, 0.5 * (self._rc_pwm_max - self._rc_pwm_min))
+        return float(np.clip((pwm_value - self._rc_pwm_trim) / span, -1.0, 1.0))
+
+    def _norm_throttle_pwm(self, pwm_value: float) -> float:
+        span = max(1.0, self._rc_pwm_max - self._rc_pwm_min)
+        return float(np.clip((pwm_value - self._rc_pwm_min) / span, 0.0, 1.0))
+    def _on_rc_out(self, msg: Any) -> None:
+        try:
+            channels = np.asarray(msg.channels, dtype=np.float64).reshape(-1)
+            if channels.size == 0:
+                return
+
+            n_surfaces = min(5, self._aux.shape[0] - 1)
+            for i in range(n_surfaces):
+                if i >= self._rc_surface_channel_indices.size:
+                    break
+                ch_idx = int(self._rc_surface_channel_indices[i])
+                if 0 <= ch_idx < channels.size:
+                    self._aux[i] = self._norm_surface_pwm(channels[ch_idx])
+
+            if self._aux.shape[0] >= 6:
+                t_idx = self._rc_throttle_channel_index
+                if 0 <= t_idx < channels.size:
+                    self._aux[5] = self._norm_throttle_pwm(channels[t_idx])
+
+            self._state_update_seq += 1
+        except Exception:
+            return
+
+    @staticmethod
+    def _ros_image_to_array(msg: Any) -> None | np.ndarray:
+        h = int(getattr(msg, "height", 0))
+        w = int(getattr(msg, "width", 0))
+        step = int(getattr(msg, "step", 0))
+        enc = str(getattr(msg, "encoding", "")).lower()
+        data = getattr(msg, "data", None)
+        if h <= 0 or w <= 0 or step <= 0 or data is None:
+            return None
+
+        enc_map: dict[str, tuple[Any, int]] = {
+            "mono8": (np.uint8, 1),
+            "8uc1": (np.uint8, 1),
+            "8sc1": (np.int8, 1),
+            "16uc1": (np.uint16, 1),
+            "16sc1": (np.int16, 1),
+            "32sc1": (np.int32, 1),
+            "32fc1": (np.float32, 1),
+            "rgb8": (np.uint8, 3),
+            "bgr8": (np.uint8, 3),
+            "rgba8": (np.uint8, 4),
+            "bgra8": (np.uint8, 4),
+        }
+        if enc not in enc_map:
+            return None
+
+        dtype, channels = enc_map[enc]
+        itemsize = np.dtype(dtype).itemsize
+        row_elems = step // itemsize
+        needed = w * channels
+        if row_elems < needed:
+            return None
+
+        arr = np.frombuffer(data, dtype=dtype)
+        expected = h * row_elems
+        if arr.size < expected:
+            return None
+        arr = arr[:expected].reshape(h, row_elems)
+        arr = arr[:, :needed]
+        if channels == 1:
+            arr = arr.reshape(h, w, 1)
+        else:
+            arr = arr.reshape(h, w, channels)
+        return np.ascontiguousarray(arr)
+
+    @staticmethod
+    def _depth_meters_to_buffer(depth_m: np.ndarray) -> np.ndarray:
+        near = 0.1
+        far = 255.0
+        z = np.asarray(depth_m, dtype=np.float32)
+        out = np.zeros_like(z, dtype=np.float32)
+        valid = np.isfinite(z) & (z > 0.0)
+        denom = np.maximum(z[valid] * (far - near), 1e-9)
+        out[valid] = (far * (z[valid] - near)) / denom
+        return np.clip(out, 0.0, 1.0)
+
+    def _on_rgb_image(self, msg: Any) -> None:
+        try:
+            arr = self._ros_image_to_array(msg)
+            if arr is None:
+                return
+
+            enc = str(getattr(msg, "encoding", "")).lower()
+            if enc == "bgr8":
+                arr = arr[..., ::-1]
+            elif enc == "bgra8":
+                arr = arr[..., [2, 1, 0, 3]]
+
+            if arr.shape[-1] == 3:
+                alpha = np.full((arr.shape[0], arr.shape[1], 1), 255, dtype=np.uint8)
+                rgba = np.concatenate([arr.astype(np.uint8, copy=False), alpha], axis=-1)
+            elif arr.shape[-1] == 4:
+                rgba = arr.astype(np.uint8, copy=False)
+            else:
+                gray = arr[..., 0].astype(np.uint8, copy=False)
+                rgba = np.repeat(gray[..., None], 4, axis=-1)
+                rgba[..., 3] = 255
+
+            drone = self.drones[0]
+            drone.rgbaImg = np.ascontiguousarray(rgba)
+            if not self._has_seg_subscription:
+                drone.segImg = np.ascontiguousarray(rgba[..., :1])
+            self._state_update_seq += 1
+        except Exception:
+            return
+
+    def _on_depth_image(self, msg: Any) -> None:
+        try:
+            arr = self._ros_image_to_array(msg)
+            if arr is None:
+                return
+
+            depth = arr[..., 0]
+            enc = str(getattr(msg, "encoding", "")).lower()
+            if enc == "16uc1":
+                depth_m = depth.astype(np.float32) * 0.001
+            else:
+                depth_m = depth.astype(np.float32)
+
+            if self._vision_depth_is_meters:
+                depth_img = self._depth_meters_to_buffer(depth_m)
+            else:
+                depth_img = np.clip(depth_m, 0.0, 1.0)
+
+            self.drones[0].depthImg = np.ascontiguousarray(depth_img[..., None])
+            self._state_update_seq += 1
+        except Exception:
+            return
+
+    def _on_seg_image(self, msg: Any) -> None:
+        try:
+            arr = self._ros_image_to_array(msg)
+            if arr is None:
+                return
+            self.drones[0].segImg = np.ascontiguousarray(arr[..., :1])
             self._state_update_seq += 1
         except Exception:
             return

--- a/envs/fixedwing_envs/ardupilot_base_waypoint.py
+++ b/envs/fixedwing_envs/ardupilot_base_waypoint.py
@@ -1,0 +1,181 @@
+"""Waypoint handler decoupled from PyFlyt rendering/Bullet visuals."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+
+class WaypointHandler:
+    """Lightweight waypoint handler for ArduPilot+Gazebo pipelines.
+
+    Keeps the same public interface used by existing environments, but:
+    - only samples/manages waypoint coordinates,
+    - does not spawn visual target bodies in Bullet.
+    """
+
+    def __init__(
+        self,
+        enable_render: bool,
+        num_targets: int,
+        use_yaw_targets: bool,
+        goal_reach_distance: float,
+        goal_reach_angle: float,
+        flight_dome_size: float,
+        min_height: float,
+        np_random: np.random.Generator,
+    ):
+        self.enable_render = enable_render
+        self.num_targets = num_targets
+        self.use_yaw_targets = use_yaw_targets
+        self.goal_reach_distance = goal_reach_distance
+        self.goal_reach_angle = goal_reach_angle
+        self.flight_dome_size = flight_dome_size
+        self.min_height = min_height
+        self.np_random = np_random
+
+        self.p: Any = None
+        self.targets: np.ndarray = np.zeros((0, 3), dtype=np.float64)
+        self.yaw_targets: np.ndarray = np.zeros((0,), dtype=np.float64)
+        self.new_distance = np.inf
+        self.old_distance = np.inf
+        self.yaw_error_scalar = np.inf
+
+    def reset(
+        self,
+        p: Any,
+        np_random: None | np.random.Generator = None,
+    ) -> None:
+        """Reset waypoints.
+
+        Args:
+            p: kept for interface compatibility; may provide quaternion->matrix helper.
+            np_random: optional RNG override.
+        """
+        self.p = p
+        if np_random is not None:
+            self.np_random = np_random
+
+        self.new_distance = np.inf
+        self.old_distance = np.inf
+        self.yaw_error_scalar = np.inf
+
+        self.targets = np.zeros(shape=(self.num_targets, 3), dtype=np.float64)
+        thetas = self.np_random.uniform(0.0, 2.0 * math.pi, size=(self.num_targets,))
+        phis = self.np_random.uniform(0.0, 2.0 * math.pi, size=(self.num_targets,))
+        for i, theta, phi in zip(range(self.num_targets), thetas, phis):
+            dist = self.np_random.uniform(low=1.0, high=self.flight_dome_size * 0.9)
+            x = dist * math.sin(phi) * math.cos(theta)
+            y = dist * math.sin(phi) * math.sin(theta)
+            z = abs(dist * math.cos(phi))
+            self.targets[i] = np.array(
+                [x, y, z if z > self.min_height else self.min_height],
+                dtype=np.float64,
+            )
+
+        if self.use_yaw_targets:
+            self.yaw_targets = self.np_random.uniform(
+                low=-math.pi, high=math.pi, size=(self.num_targets,)
+            ).astype(np.float64)
+        else:
+            self.yaw_targets = np.zeros((0,), dtype=np.float64)
+
+    @staticmethod
+    def _quat_xyzw_to_matrix(quaternion: np.ndarray) -> np.ndarray:
+        """Fallback quaternion(x, y, z, w) -> 3x3 rotation matrix."""
+        q = np.asarray(quaternion, dtype=np.float64).reshape(-1)
+        if q.shape[0] != 4:
+            return np.eye(3, dtype=np.float64)
+
+        x, y, z, w = q
+        xx, yy, zz = x * x, y * y, z * z
+        xy, xz, yz = x * y, x * z, y * z
+        wx, wy, wz = w * x, w * y, w * z
+
+        return np.array(
+            [
+                [1.0 - 2.0 * (yy + zz), 2.0 * (xy - wz), 2.0 * (xz + wy)],
+                [2.0 * (xy + wz), 1.0 - 2.0 * (xx + zz), 2.0 * (yz - wx)],
+                [2.0 * (xz - wy), 2.0 * (yz + wx), 1.0 - 2.0 * (xx + yy)],
+            ],
+            dtype=np.float64,
+        )
+
+    def _rotation_from_quaternion(self, quaternion: np.ndarray) -> np.ndarray:
+        if self.p is not None and hasattr(self.p, "getMatrixFromQuaternion"):
+            try:
+                mat = np.asarray(self.p.getMatrixFromQuaternion(quaternion), dtype=np.float64)
+                return mat.reshape(3, 3)
+            except Exception:
+                pass
+        return self._quat_xyzw_to_matrix(quaternion)
+
+    @property
+    def distance_to_next_target(self) -> float:
+        return self.new_distance
+
+    def distance_to_targets(
+        self,
+        ang_pos: np.ndarray,
+        lin_pos: np.ndarray,
+        quaternion: np.ndarray,
+    ) -> np.ndarray:
+        rotation = self._rotation_from_quaternion(quaternion)
+
+        targets_arr = np.asarray(self.targets, dtype=np.float64)
+        if targets_arr.ndim != 2 or targets_arr.shape[0] == 0:
+            self.old_distance = self.new_distance
+            self.new_distance = np.inf
+            if self.use_yaw_targets:
+                return np.zeros((0, 4), dtype=np.float64)
+            return np.zeros((0, 3), dtype=np.float64)
+
+        target_deltas = np.matmul((targets_arr - lin_pos), rotation)
+
+        self.old_distance = self.new_distance
+        self.new_distance = float(np.linalg.norm(target_deltas[0]))
+
+        if self.use_yaw_targets:
+            yaw_targets_arr = np.asarray(self.yaw_targets, dtype=np.float64).reshape(-1)
+            yaw_errors = yaw_targets_arr - float(ang_pos[-1])
+            yaw_errors[yaw_errors > math.pi] -= 2.0 * math.pi
+            yaw_errors[yaw_errors < -math.pi] += 2.0 * math.pi
+            yaw_errors = yaw_errors[..., None]
+            target_deltas = np.concatenate([target_deltas, yaw_errors], axis=-1)
+            self.yaw_error_scalar = float(np.abs(yaw_errors[0])) if yaw_errors.size else np.inf
+
+        return target_deltas
+
+    @property
+    def progress_to_next_target(self) -> float:
+        if np.any(np.isinf(self.old_distance + self.new_distance)):
+            return 0.0
+        return float(self.old_distance - self.new_distance)
+
+    @property
+    def target_reached(self) -> bool:
+        if not self.new_distance < self.goal_reach_distance:
+            return False
+        if not self.use_yaw_targets:
+            return True
+        return bool(self.yaw_error_scalar < self.goal_reach_angle)
+
+    def advance_targets(self) -> None:
+        targets_arr = np.asarray(self.targets, dtype=np.float64)
+        if targets_arr.ndim == 2 and targets_arr.shape[0] > 1:
+            self.targets = targets_arr[1:]
+            if self.use_yaw_targets:
+                self.yaw_targets = np.asarray(self.yaw_targets, dtype=np.float64)[1:]
+        else:
+            self.targets = np.zeros((0, 3), dtype=np.float64)
+            self.yaw_targets = np.zeros((0,), dtype=np.float64)
+
+    @property
+    def num_targets_reached(self) -> int:
+        return int(self.num_targets - len(self.targets))
+
+    @property
+    def all_targets_reached(self) -> bool:
+        return len(self.targets) == 0

--- a/envs/fixedwing_waypoint_objlock_env.py
+++ b/envs/fixedwing_waypoint_objlock_env.py
@@ -10,8 +10,10 @@ import pybullet_data
 from gymnasium import spaces
 
 from PyFlyt.core.abstractions.camera import Camera
-from envs.fixedwing_envs.fixedwing_base_env import FixedwingBaseEnv
-from PyFlyt.gym_envs.utils.waypoint_handler import WaypointHandler
+# from envs.fixedwing_envs.fixedwing_base_env import FixedwingBaseEnv
+from envs.fixedwing_envs.ardupilot_base_env import FixedwingBaseEnv
+# from PyFlyt.gym_envs.utils.waypoint_handler import WaypointHandler
+from envs.fixedwing_envs.ardupilot_base_waypoint import WaypointHandler
 
 
 class FixedwingWaypointObjLockEnv(FixedwingBaseEnv):


### PR DESCRIPTION
创建了ardupilot_base_env.py和ardupilot_base_waypoint.py基类用以替换fixedwing_base_env.py基类内容，具体包括：
1、FixedwingWaypointObjLockEnv等可通过修改import直接继承ardupilot基类，基类名称均为FixedwingBaseEnv
2、在ardupilot_base_env.py中添加env等类，原有的self.env从self.env = Aviary改为了自建的类，其中包含了需调用的同名函数，借由ros topic实现观测变量的更新，其余基类函数借由mavros实现同名功能
3、ardupilot_base_waypoint是为了替换fixedwing_waypoint_objlock_env中的WaypointHandler，原WaypointHandler需Aviary的对象创建。为不依赖Pyflyt，创建同名WaypointHandler类，实现相关功能
4、主要核心内容：通过mavros实现ardupilot中飞机状态量的更新，进而实现compute_attitude、compute_auxiliary等方法更新；通过订阅gazebo相机节点更新self.drone.depth以及rgbimg。gazebo中虚拟相机可提供的只有深度相机影像与光学影像
还需修改的内容
1、关于所提供的输入影像，depthImg可通过gazebo的节点提供，但segImg语义分割影像不能提供，还需进一步通过原始rgb影像处理后，提供drone.segImg，这一步未实现
2、关于duck对象的创建与导入，整个流程高度依赖pyflyt环境，不太好单独隔离拆除。需删除原有创建duck的逻辑，然后通过指定识别gazebo环境中已有目标影像进行判断，比如楼房、车辆等。准备执行的逻辑是先随机生成一系列waypoint进行追点飞行，然后追点完成后在附近搜索预期目标，计算target距离进行修正。但目前duck、target等初始化均需依赖pyflyt，未分离
3、关于障碍物的创建与导入需整个删除，具体流程还未进行